### PR TITLE
fix compile error

### DIFF
--- a/scalprod.spyx
+++ b/scalprod.spyx
@@ -20,7 +20,7 @@ def directProd(c,y,kap):
   cdef sage.rings.integer.Integer cz=<sage.rings.integer.Integer>c
   return ZZ(directScal(kap, cz.value, yz.value)) >> (getGMP_NUMB_BITS()-32)
 
-from libc.stdlib cimport calloc
+from libc.stdlib cimport calloc, free
 from sage.all import ZZ
 
 def partialProd(c,y,kap):


### PR DESCRIPTION
free() seems to require an import on my version of sage (v5.8)
