### PR TITLE
Fix mistake when encrypting a bit with PkRecrypt

### DIFF
--- a/dghv.sage
+++ b/dghv.sage
@@ -177,7 +177,7 @@ class PkRecrypt(Pk):
     f=[Ciphertext(ZZ.random_element(2^self.alpha),self) for i in range(self.tau)]
 
     c=sum2(ci*fi for ci,fi in izip(self.x.ciphertexts(self),f))+\
-           Ciphertext(ZZ.random_element(2^rhop),self) + Ciphertext(m,self)
+           Ciphertext(2*ZZ.random_element(2^rhop),self) + Ciphertext(m,self)
     if verbose: print "Encrypt",cputime(subprocesses=True)-t
     c.degree=1
     return c


### PR DESCRIPTION
The random used in the encryption of a bit `m` should be an even integer in `[-2^(rho+1),2^(rho+1)]`
